### PR TITLE
Fix for k8s deployments & pv manifests

### DIFF
--- a/deploy/databases/postgresql-accountmicroservice-volume.yml
+++ b/deploy/databases/postgresql-accountmicroservice-volume.yml
@@ -13,7 +13,7 @@ spec:
   accessModes:
     - ReadWriteMany
   hostPath:
-    path: "/mnt/data"
+    path: "/mnt/data/accountmicroservice"
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/deploy/databases/postgresql-linkmicroservice-volume.yml
+++ b/deploy/databases/postgresql-linkmicroservice-volume.yml
@@ -13,7 +13,7 @@ spec:
   accessModes:
     - ReadWriteMany
   hostPath:
-    path: "/mnt/data"
+    path: "/mnt/data/linkmicroservice"
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/deploy/logging/seq-volume.yml
+++ b/deploy/logging/seq-volume.yml
@@ -13,7 +13,7 @@ spec:
   accessModes:
     - ReadWriteMany
   hostPath:
-    path: "/mnt/data"
+    path: "/mnt/data/seq"
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/deploy/projects/accountmicroservice-deployment.yml
+++ b/deploy/projects/accountmicroservice-deployment.yml
@@ -48,7 +48,7 @@ spec:
                   key: issuer
                   optional: false
             - name: "Seq_ServerUrl"
-              value: "my-seq.default.svc.cluster.local"
+              value: "http://my-seq.default.svc.cluster.local"
             - name: "Seq_ApiKey"
               valueFrom:
                 secretKeyRef:

--- a/deploy/projects/filemicroservice-deployment.yml
+++ b/deploy/projects/filemicroservice-deployment.yml
@@ -38,7 +38,7 @@ spec:
                   key: issuer
                   optional: false
             - name: "Seq_ServerUrl"
-              value: "my-seq.default.svc.cluster.local"
+              value: "http://my-seq.default.svc.cluster.local"
             - name: "Seq_ApiKey"
               valueFrom:
                 secretKeyRef:

--- a/deploy/projects/linkmicroservice-deployment.yml
+++ b/deploy/projects/linkmicroservice-deployment.yml
@@ -52,7 +52,7 @@ spec:
                   key: issuer
                   optional: false
             - name: "Seq_ServerUrl"
-              value: "my-seq.default.svc.cluster.local"
+              value: "http://my-seq.default.svc.cluster.local"
             - name: "Seq_ApiKey"
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
* Added seperate 'hostPath' for each pv, so the pods can't access
each others data.
  - This makes it so that the databases cannot overwrite each others data.
* Added the correct URL for Seq, to send log entries to.
  - To prevent crashes when starting the application.